### PR TITLE
Potential fix for code scanning alert no. 4: Information exposure through an exception

### DIFF
--- a/src/integrador/admin.py
+++ b/src/integrador/admin.py
@@ -16,7 +16,9 @@ from import_export.resources import ModelResource
 from base.admin import BaseModelAdmin
 from integrador.models import Ambiente, Solicitacao
 from integrador.brokers.suap2local_suap import Suap2LocalSuapBroker
+import logging
 
+logger = logging.getLogger(__name__)
 
 ####
 # Admins
@@ -164,6 +166,7 @@ class SolicitacaoAdmin(BaseModelAdmin):
             if solicitacao is None:
                 raise Exception("Erro desconhecido.")
             return HttpResponseRedirect(reverse("admin:integrador_solicitacao_view", args=[solicitacao.id]))
-        except Exception as e:
-            return HttpResponse(f"{e}")
+        except Exception:
+            logger.exception("Error while syncing Moodle for Solicitacao %s", s.id)
+            return HttpResponse(_("An internal error has occurred while syncing. Please contact the administrator."))
 


### PR DESCRIPTION
Potential fix for [https://github.com/cte-zl-ifrn/integration__integrador/security/code-scanning/4](https://github.com/cte-zl-ifrn/integration__integrador/security/code-scanning/4)

To fix the problem, the exception details should be kept on the server (via logging or other monitoring) and the HTTP response should contain only a generic, user-friendly error message. This preserves debuggability while preventing attackers from learning internal details from exception messages.

The best targeted fix here is to modify the `except` block in `sync_moodle_view` (lines 167–168) so that it no longer returns `HttpResponse(f"{e}")`. Instead, we should log the exception and then return a generic message such as “An internal error has occurred while syncing.” Since we must not assume other project structure, using Python’s standard `logging` module is a safe choice. We will add an import for `logging` at the top of `src/integrador/admin.py` and create a module-level logger (for example, `logger = logging.getLogger(__name__)`). Then, in the `except` block, we call `logger.exception(...)` to record the full stack trace and return a generic `HttpResponse` to the user.

Concretely:
- In `src/integrador/admin.py`, add `import logging` near the existing imports and define `logger = logging.getLogger(__name__)` once at the module level.
- Replace `except Exception as e:` / `return HttpResponse(f"{e}")` with:
  - `logger.exception("Error while syncing Moodle for Solicitacao %s", s.id)`
  - A generic `HttpResponse` body, possibly using `gettext` (`_`) for translatability, for example: `return HttpResponse(_("An internal error has occurred while syncing. Please contact the administrator."))`
This retains existing functionality (the sync either redirects on success or shows a failure message) but prevents raw exception content from being exposed to the client.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
