### PR TITLE
Potential fix for code scanning alert no. 5: Information exposure through an exception

### DIFF
--- a/src/integrador/admin.py
+++ b/src/integrador/admin.py
@@ -176,5 +176,5 @@ class SolicitacaoAdmin(BaseModelAdmin):
             return HttpResponseRedirect(reverse("admin:integrador_solicitacao_view", args=[solicitacao.id]))
         except Exception as e:
             logger.exception(f"Error while syncing Moodle for Solicitacao {s.id}. ERROR: {e}")
-            return HttpResponse(_("An internal error has occurred while syncing. Please contact the administrator.") + f'. ERROR: {e}')
+            return HttpResponse(_("An internal error has occurred while syncing. Please contact the administrator."))
 


### PR DESCRIPTION
Potential fix for [https://github.com/cte-zl-ifrn/integration-integrador_ava/security/code-scanning/5](https://github.com/cte-zl-ifrn/integration-integrador_ava/security/code-scanning/5)

In general, to fix this kind of problem you should avoid including raw exception details in responses sent to the client. Instead, log the full exception server-side (including stack trace) and return a generic, user-friendly message that does not contain sensitive information.

For this specific case in `src/integrador/admin.py`, we already log the exception with `logger.exception`, which captures both the message and stack trace. The only problematic part is concatenating `f'. ERROR: {e}'` to the translated string returned in the `HttpResponse`. The best minimal fix is to remove the exception details from the HTTP response while keeping the logging behavior unchanged.

Concretely:
- Keep the `logger.exception` call in the `except` block of `sync_moodle_view` as-is (or at most simplify its message).
- Change the `HttpResponse` to return only the generic translated message: `_("An internal error has occurred while syncing. Please contact the administrator.")`.
- Do not add any new dependencies; the existing imports (logging, `_` from `django.utils.translation`, `HttpResponse`) already cover what we need.

Only the lines around 177–179 in `sync_moodle_view` need to be updated.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
