### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -1,5 +1,8 @@
 name: Build, push and deploy Docker service
 
+permissions:
+  contents: read
+
 on:
   push:
     # branches:


### PR DESCRIPTION
Potential fix for [https://github.com/cte-zl-ifrn/integration-integrador_ava/security/code-scanning/7](https://github.com/cte-zl-ifrn/integration-integrador_ava/security/code-scanning/7)

In general, the fix is to add an explicit `permissions:` block that grants only the minimum required scopes to the `GITHUB_TOKEN`. Since this workflow only needs to read the repository contents (for `actions/checkout`) and does not appear to modify any GitHub resources, the minimal and correct configuration is `contents: read`. This can be set at the root of the workflow (affecting all jobs) or separately per job; here, adding it at the workflow root is simplest and keeps behavior unchanged.

Concretely, edit `.github/workflows/docker-deploy.yml` near the top of the file. Right after the `name:` line (line 1) and before the `on:` trigger block (line 3), insert a `permissions:` section:

```yaml
permissions:
  contents: read
```

This will ensure that both `build-and-push` and `deploy` jobs run with a `GITHUB_TOKEN` that can only read repository contents, which is sufficient for `actions/checkout` and does not interfere with Docker Hub login or remote deployment commands that rely on secrets and the runner environment rather than GitHub write APIs. No imports or additional methods are needed, as this is purely a workflow-configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
