### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -1,5 +1,8 @@
 name: Build, push and deploy Docker service
 
+permissions:
+  contents: read
+
 on:
   push:
     # branches:


### PR DESCRIPTION
Potential fix for [https://github.com/cte-zl-ifrn/integration-integrador_ava/security/code-scanning/8](https://github.com/cte-zl-ifrn/integration-integrador_ava/security/code-scanning/8)

In general, the fix is to explicitly declare a `permissions` block that grants only the minimal required scopes to the `GITHUB_TOKEN`. Since this workflow only needs to read repository contents (for `actions/checkout`) and does not appear to modify GitHub resources, `contents: read` is sufficient and aligns with the recommendation.

The best way to fix this without changing existing functionality is to add a top-level `permissions` block just under the `name` (or `on`) key in `.github/workflows/docker-deploy.yml`. This block will apply to all jobs (`build-and-push` and `deploy`) that don’t override permissions. Concretely, add:

```yaml
permissions:
  contents: read
```

after line 1 or after the `on:` block. No imports or additional methods are needed, as this is pure workflow configuration. No other lines require modification.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
