### PR TITLE
Potential fix for code scanning alert no. 32: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,8 @@ on:
   release:
     types: [published]
 
+permissions: {}
+
 jobs:
 
   deploy:


### PR DESCRIPTION
Potential fix for [https://github.com/cte-zl-ifrn/integration-integrador_ava/security/code-scanning/32](https://github.com/cte-zl-ifrn/integration-integrador_ava/security/code-scanning/32)

Add an explicit `permissions` block to the workflow (best at root level here, since only one job is shown and no job-specific override is needed).  
For this deploy snippet, the safest least-privilege default is:

```yml
permissions: {}
```

This disables all `GITHUB_TOKEN` scopes unless later explicitly granted, and does not change current job logic (which only runs local shell commands).  
Edit `.github/workflows/deploy.yml` near the top-level keys: insert `permissions: {}` after `on:` (or after `name:`) and before `jobs:`.

No imports, methods, or additional definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
